### PR TITLE
add support for unloading using dlclose

### DIFF
--- a/src/libc_addresses.rs
+++ b/src/libc_addresses.rs
@@ -7,6 +7,7 @@ use libloading::os::unix::Library;
 pub struct LibcAddrs {
     pub(crate) malloc: u64,
     pub(crate) dlopen: u64,
+    pub(crate) dlclose: u64,
     pub(crate) free: u64,
 }
 
@@ -29,6 +30,7 @@ impl LibcAddrs {
         let addrs = Self {
             malloc: addr_of("malloc")?,
             dlopen: addr_of("dlopen")?,
+            dlclose: addr_of("dlclose")?,
             free: addr_of("free")?,
         };
         log::debug!("Got libc addresses for current process: {addrs:x?}");
@@ -44,6 +46,7 @@ impl LibcAddrs {
         Self {
             malloc: self.malloc - old_base + new_base,
             dlopen: self.dlopen - old_base + new_base,
+            dlclose: self.dlclose - old_base + new_base,
             free: self.free - old_base + new_base,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,9 @@ impl Args {
         } else {
             panic!("no target specified, but clap should have caught this");
         };
-        Injector::attach(process)?.inject(&self.library)
+        Injector::attach(process)?.inject(&self.library)?;
+
+        Ok(())
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -25,6 +25,7 @@ impl Process {
     /// Get a process by its PID.
     pub fn get(id: u32) -> Result<Self> {
         // https://unix.stackexchange.com/a/16884 - A PID should fit in 31 bits comfortably.
+        #![allow(clippy::missing_panics_doc)]
         let id = i32::try_from(id).expect("PID to fit in an i32");
         log::trace!("Getting process with PID {}", id);
         Ok(Self(


### PR DESCRIPTION
Added the ability to unload the injected lib using dlclose.

TODO: add support in the executable for unloading, though I don't really know how that would be possible as dlopen/dlclose is reference counted.